### PR TITLE
Install or upgrade wp-cli when restoring a WordPress vhost.

### DIFF
--- a/bin/.path/.gitignore
+++ b/bin/.path/.gitignore
@@ -1,2 +1,3 @@
 *
 !drush
+!wpcli

--- a/bin/.path/wpcli
+++ b/bin/.path/wpcli
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# this script tries to select the 'best' wp-cli (wpcli) version
+# available to be run
+
+self_bin=`readlink -e "$0"`
+curr_dir=`dirname "$self_bin"`
+devpanel_dir=`readlink -e "$curr_dir/../.."`
+
+home_wpcli="$HOME/bin/wpcli"
+devpanel_wpcli="$devpanel_dir/bin/packages/wpcli/wp-cli.phar"
+
+# first check for wpcli on the user directory
+# if not found, and there isn't another wpcli in PATH, fallback to
+#  ...the wp-cli version shipped with devPanel
+if [ -f "$home_wpcli" -a -x "$home_wpcli" ]; then
+  hash -p "$home_wpcli" wpcli
+elif ! hash wpcli &>/dev/null && [ -x "$devpanel_wpcli" ]; then
+  hash -p "$devpanel_wpcli" wpcli
+elif hash wpcli &>/dev/null && [ "`hash -t wpcli`" == $0 ]; then
+  hash -p "$devpanel_wpcli" wpcli
+fi
+
+wpcli "$@"

--- a/bin/seeds/wordpress/install-wp-cli
+++ b/bin/seeds/wordpress/install-wp-cli
@@ -1,0 +1,18 @@
+#!/bin/bash -
+
+self_bin=`readlink -e "$0"`
+curr_dir=`dirname "$self_bin"`
+base_dir=`readlink -e "$curr_dir/../../.."`
+
+vhost_dir="$HOME/public_html/${USER#w_}"
+
+if ! cd "$vhost_dir"; then
+  echo "Error: unable to chdir to '$vhost_dir'" 1>&2
+  exit 1
+fi
+
+# Download (or upgrade) wp-cli.phar from the developers' distribution URL.
+curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+# Install it for the current site's user.
+mv -f wp-cli.phar "$HOME/bin/wpcli"
+chmod 755 "$HOME/bin/wpcli"

--- a/bin/seeds/wordpress/restore-vhost.functions
+++ b/bin/seeds/wordpress/restore-vhost.functions
@@ -100,6 +100,8 @@ wordpress_custom() {
 
   echo "Setting upload path"
   wordpress_set_upload_path || error "Cannot set upload path"
+
+  "$we_base_dir/bin/seeds/wordpress/install-wp-cli"
 }
 
 


### PR DESCRIPTION
I want to use [wp-cli](http://wp-cli.org/) for management of `serverlink`'ed WordPress sites, much as I might use `drush` for Drupal sites, but wp-cli does not ship inside the Web Enabled application seeds. This patch hooks into the `${subsystem}_custom` command of the WordPress's seed API to trigger an installation (or upgrade) of the latest wp-cli from its developers anytime a WordPress vhost is restored.

There might be a more elegant way to do this, and I don't know what devPanel.com's packaging rules/guidelines are, so I tried to be as site-specific possible. This patch will install/upgrade a wp-cli for each site, although it follows the Web Enabled `drush` package's guidelines as closely as I could understand them in order to allow for server-wide (instead of site-specific) `wp-cli` installs.

Also, this patch uses the non-standard command name `wpcli` rather than `wp`, in order to avoid any conflicts or confusion for folks who are already using wp-cli on devPanel managed sites. This may or may not be desirable Let me know and I can re-submit the pull request with whatever modifications you think will be most portable.
